### PR TITLE
feat(cronjob): Add more properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ Stakater [IngressMonitorController](https://github.com/stakater/IngressMonitorCo
 | `cronJob.enabled`        | Enable cronjob in application chart                                                          | `""`            |
 | `cronJob.jobs`           | cronjobs spec                                                                                | {}              |
 
-Job paramater for each cronjob object at `cronJob.jobs` 
+Job parameter for each cronjob object at `cronJob.jobs` 
 
 | Name                               | Description                                                                                  
 | -----------------------------------| -------------------------------------------------------------------------------------------- |
@@ -447,7 +447,7 @@ Job paramater for each cronjob object at `cronJob.jobs`
 | `<name>.image.repository`          | Repository of container image of cronjob                                                     |
 | `<name>.image.tag`                 | Tag of container image of cronjob                                                            |
 | `<name>.image.digest`              | Digest of container image of cronjob                                                         |
-| `<name>.image.imagePullPolicy`     | ImagePullPolicy of container image ofcronjob                                                                                                                           |
+| `<name>.image.imagePullPolicy`     | ImagePullPolicy of container image of cronjob                                                                                                                           |
 | `<name>.command`                   | Command of container of job                                                                  |
 | `<name>.args`                      | Args of container of job                                                                     |
 | `<name>.resources`                 | Resources of container of job                                                                |
@@ -463,6 +463,8 @@ Job paramater for each cronjob object at `cronJob.jobs`
 | `<name>.tolerations`               | Tolerations of cronjob                                                                       | 
 | `<name>.restartPolicy`             | RestartPolicy of cronjob                                                                     |
 | `<name>.imagePullSecrets`          | ImagePullSecrets of cronjob                                                                     |
+| `<name>.activeDeadlineSeconds` | ActiveDeadlineSeconds of job |
+| `<name>.additionalPodAnnotations` | Additional annotations of pod of job |
 
 ## Naming convention for ConfigMap, Secret, SealedSecret and ExternalSecret
 

--- a/README.md
+++ b/README.md
@@ -441,30 +441,30 @@ Stakater [IngressMonitorController](https://github.com/stakater/IngressMonitorCo
 
 Job parameter for each cronjob object at `cronJob.jobs` 
 
-| Name                               | Description                                                                                  
-| -----------------------------------| -------------------------------------------------------------------------------------------- |
-| `<name>.schedule`                  | Schedule of cronjob                                                                          | 
-| `<name>.image.repository`          | Repository of container image of cronjob                                                     |
-| `<name>.image.tag`                 | Tag of container image of cronjob                                                            |
-| `<name>.image.digest`              | Digest of container image of cronjob                                                         |
-| `<name>.image.imagePullPolicy`     | ImagePullPolicy of container image of cronjob                                                                                                                           |
-| `<name>.command`                   | Command of container of job                                                                  |
-| `<name>.args`                      | Args of container of job                                                                     |
-| `<name>.resources`                 | Resources of container of job                                                                |
-| `<name>.additionalLabels`          | Additional labels of cronjob                                                                 |
-| `<name>.annotations`               | Annotation of cronjob                                                                        |    
-| `<name>.successfulJobsHistoryLimit`| Successful jobs historyLimit of cronjob                                                                           |    
-| `<name>.concurrencyPolicy`         | ConcurrencyPolicy of cronjob                                                                 |    
-| `<name>.failedJobsHistoryLimit`    | FailedJobsHistoryLimit of cronjob                                                            |    
-| `<name>.volumeMounts`              | Volume mounts  of cronjob                                                                    |  
-| `<name>.volumes`                    | Volumes  of cronjob                                                                          | 
-| `<name>.nodeSelector`              | Node selector of cronjob                                                                     | 
-| `<name>.affinity`                  | Affinity of cronjob                                                                          | 
-| `<name>.tolerations`               | Tolerations of cronjob                                                                       | 
-| `<name>.restartPolicy`             | RestartPolicy of cronjob                                                                     |
-| `<name>.imagePullSecrets`          | ImagePullSecrets of cronjob                                                                     |
-| `<name>.activeDeadlineSeconds` | ActiveDeadlineSeconds of job |
-| `<name>.additionalPodAnnotations` | Additional annotations of pod of job |
+| Name                                | Description                                   |
+| ----------------------------------- | --------------------------------------------- |
+| `<name>.schedule`                   | Schedule of cronjob                           |
+| `<name>.image.repository`           | Repository of container image of cronjob      |
+| `<name>.image.tag`                  | Tag of container image of cronjob             |
+| `<name>.image.digest`               | Digest of container image of cronjob          |
+| `<name>.image.imagePullPolicy`      | ImagePullPolicy of container image of cronjob |
+| `<name>.command`                    | Command of container of job                   |
+| `<name>.args`                       | Args of container of job                      |
+| `<name>.resources`                  | Resources of container of job                 |
+| `<name>.additionalLabels`           | Additional labels of cronjob                  |
+| `<name>.annotations`                | Annotation of cronjob                         |
+| `<name>.successfulJobsHistoryLimit` | Successful jobs historyLimit of cronjob       |
+| `<name>.concurrencyPolicy`          | ConcurrencyPolicy of cronjob                  |
+| `<name>.failedJobsHistoryLimit`     | FailedJobsHistoryLimit of cronjob             |
+| `<name>.volumeMounts`               | Volume mounts  of cronjob                     |
+| `<name>.volumes`                    | Volumes  of cronjob                           |
+| `<name>.nodeSelector`               | Node selector of cronjob                      |
+| `<name>.affinity`                   | Affinity of cronjob                           |
+| `<name>.tolerations`                | Tolerations of cronjob                        |
+| `<name>.restartPolicy`              | RestartPolicy of cronjob                      |
+| `<name>.imagePullSecrets`           | ImagePullSecrets of cronjob                   |
+| `<name>.activeDeadlineSeconds`      | ActiveDeadlineSeconds of job                  |
+| `<name>.additionalPodAnnotations`   | Additional annotations of pod of job          |
 
 ## Naming convention for ConfigMap, Secret, SealedSecret and ExternalSecret
 

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -38,6 +38,10 @@ spec:
         metadata:
           labels:
           {{- include "application.labels" $ | nindent 12 }}
+          {{- with $job.additionalPodAnnotations }}
+          annotations:
+{{ toYaml . | indent 12 }}
+          {{- end }}
         spec:
           {{- if $.Values.rbac.serviceAccount.name }}
           serviceAccountName: {{ $.Values.rbac.serviceAccount.name }}

--- a/application/templates/cronjob.yaml
+++ b/application/templates/cronjob.yaml
@@ -31,6 +31,9 @@ spec:
 {{ end }}
   jobTemplate:
     spec:
+{{- if $job.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ $job.activeDeadlineSeconds }}
+{{ end }}
       template:
         metadata:
           labels:


### PR DESCRIPTION
This PR adds support for the following properties in CronJob:
- `.spec.jobTemplate.spec.activeDeadlineSeconds`
- `.spec.jobTemplate.spec.template.metadata.annotations`